### PR TITLE
Issue #2 🎫: Horizontal IDE like Navbar (Desktop Navbar)

### DIFF
--- a/.vscode/terminals.json
+++ b/.vscode/terminals.json
@@ -1,0 +1,40 @@
+{
+  "autorun": true,
+  "focus": true,
+  "preLaunchTask": "",
+  "terminals": [
+    {
+      "name": "Commit",
+      "type": "bash",
+      "color": "terminal.ansiBlue",
+      "icon": "git-commit",
+      "command": "git branch -a"
+    },
+    {
+      "name": "React CLI",
+      "type": "bash",
+      "color": "terminal.ansiWhite",
+      "icon": "terminal"
+    },
+    {
+      "name": "React Dev Server",
+      "type": "bash",
+      "color": "terminal.ansiCyan",
+      "icon": "browser",
+      "command": "npm start"
+    },
+    {
+      "name": "Jest",
+      "type": "bash",
+      "color": "terminal.ansiYellow",
+      "icon": "microscope"
+    },
+    {
+      "name": "Linters",
+      "type": "bash",
+      "color": "terminal.ansiGreen",
+      "icon": "checklist",
+      "command": "npx eslint '**/*.{ts,tsx}' && npx stylelint '**/*.{css,scss}'"
+    }
+  ]
+}

--- a/src/components/UI/FileTabsNavbar.tsx
+++ b/src/components/UI/FileTabsNavbar.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { FaReact } from 'react-icons/fa';
+
+import '../../styles/UI/FileTabsNavbar.scss';
+
+const FileTabsNavbar: React.FC = () => {
+  const iconSize = 26;
+
+  return (
+    <nav className="file-tabs-navbar">
+      <ul>
+        <li>
+          <Link to="/iturres-reactive-portfolio/homepage">
+            <FaReact
+              size={iconSize}
+              className="tech-logo"
+              title="about me page"
+            />
+            About.tsx
+          </Link>
+        </li>
+        <li>
+          <Link to="/iturres-reactive-portfolio/homepage/projects">
+            <FaReact
+              size={iconSize}
+              className="tech-logo"
+              title="my projects page"
+            />
+            Projects.tsx
+          </Link>
+        </li>
+        <li>
+          <Link to="/iturres-reactive-portfolio/homepage/contact">
+            <FaReact
+              size={iconSize}
+              className="tech-logo"
+              title="contact page"
+            />
+            Contact.tsx
+          </Link>
+        </li>
+        <li>
+          <Link to="/iturres-reactive-portfolio/homepage/expertise">
+            <FaReact
+              size={iconSize}
+              className="tech-logo"
+              title="expertise page"
+            />
+            Expertise.tsx
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default FileTabsNavbar;

--- a/src/components/UI/FileTabsNavbar.tsx
+++ b/src/components/UI/FileTabsNavbar.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useMemo } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 
 import { FaReact } from 'react-icons/fa';
 
@@ -8,11 +8,26 @@ import '../../styles/UI/FileTabsNavbar.scss';
 const FileTabsNavbar: React.FC = () => {
   const iconSize = 26;
 
+  const { pathname } = useLocation();
+
+  const paths = useMemo(
+    () => ({
+      homepage: '/iturres-reactive-portfolio/homepage',
+      projects: '/iturres-reactive-portfolio/homepage/projects',
+      contact: '/iturres-reactive-portfolio/homepage/contact',
+      expertise: '/iturres-reactive-portfolio/homepage/expertise',
+    }),
+    [],
+  );
+
   return (
     <nav className="file-tabs-navbar">
       <ul>
         <li>
-          <Link to="/iturres-reactive-portfolio/homepage">
+          <Link
+            to={paths.homepage}
+            className={pathname === paths.homepage ? 'active' : ''}
+          >
             <FaReact
               size={iconSize}
               className="tech-logo"
@@ -22,7 +37,10 @@ const FileTabsNavbar: React.FC = () => {
           </Link>
         </li>
         <li>
-          <Link to="/iturres-reactive-portfolio/homepage/projects">
+          <Link
+            to={paths.projects}
+            className={pathname === paths.projects ? 'active' : ''}
+          >
             <FaReact
               size={iconSize}
               className="tech-logo"
@@ -32,7 +50,10 @@ const FileTabsNavbar: React.FC = () => {
           </Link>
         </li>
         <li>
-          <Link to="/iturres-reactive-portfolio/homepage/contact">
+          <Link
+            to={paths.contact}
+            className={pathname === paths.contact ? 'active' : ''}
+          >
             <FaReact
               size={iconSize}
               className="tech-logo"
@@ -42,7 +63,10 @@ const FileTabsNavbar: React.FC = () => {
           </Link>
         </li>
         <li>
-          <Link to="/iturres-reactive-portfolio/homepage/expertise">
+          <Link
+            to={paths.expertise}
+            className={pathname === paths.expertise ? 'active' : ''}
+          >
             <FaReact
               size={iconSize}
               className="tech-logo"

--- a/src/components/UI/Navbar.tsx
+++ b/src/components/UI/Navbar.tsx
@@ -1,16 +1,31 @@
-import React, { CSSProperties, useRef } from 'react';
+import React, {
+  useEffect,
+  useState,
+  CSSProperties,
+  useRef,
+} from 'react';
+
 import { Link } from 'react-router-dom';
 
 import { SiAboutdotme } from 'react-icons/si';
 import { CgMenuMotion } from 'react-icons/cg';
 import { AiFillGithub, AiOutlineMail } from 'react-icons/ai';
 import { BiLogoLinkedin, BiExit } from 'react-icons/bi';
-import { FaProjectDiagram } from 'react-icons/fa';
+import { FaProjectDiagram, FaAngellist } from 'react-icons/fa';
 import { LuSquareStack } from 'react-icons/lu';
 
 import '../../styles/UI/Navbar.scss';
 
 const Navbar: React.FC = () => {
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  const minWith = 768;
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
+      setWindowWidth(window.innerWidth);
+    });
+  }, [windowWidth]);
+
   const $menu = useRef<HTMLElement>(null);
   const iconSize = 30;
 
@@ -30,15 +45,6 @@ const Navbar: React.FC = () => {
         <CgMenuMotion size={iconSize} className="text-hue-rotate" />
       </button>
       <ul>
-        <li style={{ '--elem': 0 } as CSSProperties}>
-          <Link to="/iturres-reactive-portfolio/homepage">
-            <SiAboutdotme
-              size={iconSize}
-              className="text-hue-rotate"
-              title="About me"
-            />
-          </Link>
-        </li>
         <li style={{ '--elem': 1 } as CSSProperties}>
           <a
             href="https://github.com/ITurres"
@@ -68,37 +74,66 @@ const Navbar: React.FC = () => {
           </a>
         </li>
         <li style={{ '--elem': 3 } as CSSProperties}>
-          <Link to="/iturres-reactive-portfolio/homepage/projects">
-            <FaProjectDiagram
+          <a
+            href="https://wellfound.com/u/arturo-arthur-emanuel-guerra-iturres"
+            target="_blank"
+            rel="noreferrer noopener"
+            aria-label="My Wellfound"
+          >
+            <FaAngellist
               size={iconSize}
               className="text-hue-rotate"
-              title="My Projects"
+              title="My Wellfound"
             />
-          </Link>
+          </a>
         </li>
         <li style={{ '--elem': 4 } as CSSProperties}>
-          <Link to="/iturres-reactive-portfolio/homepage/contact">
-            <AiOutlineMail
-              size={iconSize}
-              className="text-hue-rotate"
-              title="Contact me!"
-            />
-          </Link>
-        </li>
-        <li style={{ '--elem': 5 } as CSSProperties}>
           <Link to="/iturres-reactive-portfolio/">
             <BiExit size={iconSize} className="text-hue-rotate" title="Exit" />
           </Link>
         </li>
-        <li style={{ '--elem': 6 } as CSSProperties}>
-          <Link to="/iturres-reactive-portfolio/homepage/expertise">
-            <LuSquareStack
-              size={iconSize}
-              className="text-hue-rotate"
-              title="Expertise"
-            />
-          </Link>
-        </li>
+
+        {/* ! SHOW ONLY ON MOBILE */}
+        {windowWidth < minWith && (
+          <>
+            <li style={{ '--elem': 5 } as CSSProperties}>
+              <Link to="/iturres-reactive-portfolio/homepage">
+                <SiAboutdotme
+                  size={iconSize}
+                  className="text-hue-rotate"
+                  title="About me"
+                />
+              </Link>
+            </li>
+            <li style={{ '--elem': 6 } as CSSProperties}>
+              <Link to="/iturres-reactive-portfolio/homepage/projects">
+                <FaProjectDiagram
+                  size={iconSize}
+                  className="text-hue-rotate"
+                  title="My Projects"
+                />
+              </Link>
+            </li>
+            <li style={{ '--elem': 7 } as CSSProperties}>
+              <Link to="/iturres-reactive-portfolio/homepage/contact">
+                <AiOutlineMail
+                  size={iconSize}
+                  className="text-hue-rotate"
+                  title="Contact me!"
+                />
+              </Link>
+            </li>
+            <li style={{ '--elem': 8 } as CSSProperties}>
+              <Link to="/iturres-reactive-portfolio/homepage/expertise">
+                <LuSquareStack
+                  size={iconSize}
+                  className="text-hue-rotate"
+                  title="Expertise"
+                />
+              </Link>
+            </li>
+          </>
+        )}
       </ul>
     </nav>
   );

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Routes, Route, Outlet } from 'react-router-dom';
 
 import AboutPage from './AboutPage.tsx';
@@ -7,20 +7,33 @@ import Navbar from '../UI/Navbar.tsx';
 import ExpertiseSummaryPage from './ExpertiseSummaryPage.tsx';
 import ContactPage from './ContactPage.tsx';
 import ProjectsPage from './ProjectsPage.tsx';
+import FileTabsNavbar from '../UI/FileTabsNavbar.tsx';
 
-const HomePage: React.FC = () => (
-  <>
-    <LineCount />
-    <Navbar />
-    <Routes>
-      <Route path="/" element={<Outlet />}>
-        <Route path="/" element={<AboutPage />} />
-        <Route path="/expertise" element={<ExpertiseSummaryPage />} />
-        <Route path="/contact" element={<ContactPage />} />
-        <Route path="/projects" element={<ProjectsPage />} />
-      </Route>
-    </Routes>
-  </>
-);
+const HomePage: React.FC = () => {
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  const minWith = 768;
+
+  useEffect(() => {
+    window.addEventListener('resize', () => {
+      setWindowWidth(window.innerWidth);
+    });
+  }, [windowWidth]);
+
+  return (
+    <>
+      <LineCount />
+      {windowWidth > minWith && <FileTabsNavbar />}
+      <Navbar />
+      <Routes>
+        <Route path="/" element={<Outlet />}>
+          <Route path="/" element={<AboutPage />} />
+          <Route path="/expertise" element={<ExpertiseSummaryPage />} />
+          <Route path="/contact" element={<ContactPage />} />
+          <Route path="/projects" element={<ProjectsPage />} />
+        </Route>
+      </Routes>
+    </>
+  );
+};
 
 export default HomePage;

--- a/src/styles/UI/FileTabsNavbar.scss
+++ b/src/styles/UI/FileTabsNavbar.scss
@@ -1,0 +1,65 @@
+@use '../variables//colors' as colors;
+
+$dark: colors.$dark;
+$light-gray: colors.$light-gray;
+
+// stylelint-disable no-descending-specificity
+#root:has(.expertise-summary-page-bg--container) {
+  .file-tabs-navbar a {
+    // stylelint-disable-next-line
+    background-color: rgba(rgb(23, 23, 23), 0.5);
+  }
+}
+
+.file-tabs-navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  background:
+    linear-gradient(
+      90deg,
+      rgb(23, 23, 23),
+      rgb(23, 23, 23),
+      rgba(23, 23, 23, 0.605),
+      rgba(23, 23, 23, 0.221)
+    );
+  font-family: sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+
+  ul {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 2px;
+    list-style: none;
+    margin: 0 auto;
+    padding-left: 2.5rem;
+    padding-bottom: 1px; // ? to fill padding bottom gap cause from anchor element padding.
+
+    li {
+      padding: 8px 0;
+      text-decoration: none;
+
+      a {
+        background-color: rgb(27, 27, 27);
+        padding: 0.8rem 2.5rem 0.8rem 1rem;
+        text-decoration: none;
+        color: lighten($light-gray, 20%);
+        transition: all 0.1s ease-in-out;
+
+        .tech-logo {
+          padding-right: 0.5rem;
+          vertical-align: bottom;
+          color: rgb(13, 97, 181);
+        }
+
+        &:focus {
+          background-color: $dark;
+        }
+      }
+    }
+  }
+}

--- a/src/styles/UI/FileTabsNavbar.scss
+++ b/src/styles/UI/FileTabsNavbar.scss
@@ -16,14 +16,16 @@ $light-gray: colors.$light-gray;
   top: 0;
   left: 0;
   right: 0;
+  z-index: 100;
   width: 100%;
-  background: linear-gradient(
-    90deg,
-    rgb(23, 23, 23),
-    rgb(23, 23, 23),
-    rgba(23, 23, 23, 0.605),
-    rgba(23, 23, 23, 0.221)
-  );
+  background:
+    linear-gradient(
+      90deg,
+      rgb(23, 23, 23),
+      rgb(23, 23, 23),
+      rgba(23, 23, 23, 0.605),
+      rgba(23, 23, 23, 0.221)
+    );
   font-family: sans-serif;
   font-size: 1rem;
   font-weight: 500;

--- a/src/styles/UI/FileTabsNavbar.scss
+++ b/src/styles/UI/FileTabsNavbar.scss
@@ -17,14 +17,13 @@ $light-gray: colors.$light-gray;
   left: 0;
   right: 0;
   width: 100%;
-  background:
-    linear-gradient(
-      90deg,
-      rgb(23, 23, 23),
-      rgb(23, 23, 23),
-      rgba(23, 23, 23, 0.605),
-      rgba(23, 23, 23, 0.221)
-    );
+  background: linear-gradient(
+    90deg,
+    rgb(23, 23, 23),
+    rgb(23, 23, 23),
+    rgba(23, 23, 23, 0.605),
+    rgba(23, 23, 23, 0.221)
+  );
   font-family: sans-serif;
   font-size: 1rem;
   font-weight: 500;
@@ -57,6 +56,10 @@ $light-gray: colors.$light-gray;
         }
 
         &:focus {
+          background-color: $dark;
+        }
+
+        &.active {
           background-color: $dark;
         }
       }

--- a/src/styles/UI/LineCount.scss
+++ b/src/styles/UI/LineCount.scss
@@ -6,7 +6,9 @@ $light-gray: colors.$light-gray;
 .line-count {
   display: none;
 
-  @media (min-width: 630px) {
+  @media (min-width: 768px) {
+    margin-top: 2.6rem;
+
     & {
       display: flex;
       flex-direction: column;

--- a/src/styles/UI/Navbar.scss
+++ b/src/styles/UI/Navbar.scss
@@ -1,6 +1,6 @@
 @use '../variables/colors' as colors;
 
-$elementsInNavbar: 7;
+$elementsInNavbar: 8;
 
 $color2: colors.$color2;
 $color1: colors.$color1;

--- a/src/styles/pages/AboutPage.scss
+++ b/src/styles/pages/AboutPage.scss
@@ -66,10 +66,17 @@ $color1: colors.$color1;
   }
 
   @media (min-width: 768px) {
+    @include mixins.component-code-snippet(
+      'const About = () => {',
+      $color1,
+      $color1,
+      4
+    );
+
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    height: 100vh;
+    height: 90vh;
 
     &__about {
       width: 60%;

--- a/src/styles/pages/ContactPage.scss
+++ b/src/styles/pages/ContactPage.scss
@@ -32,9 +32,15 @@ body:has(.drone) {
     -2
   );
 
-  @media (min-width: 768px) {
+  @media screen and (min-width: 768px) {
     width: 90%;
+    min-height: 95vh;
 
-    @include mixins.component-code-snippet('const Contact = () => {');
+    @include mixins.component-code-snippet(
+      'const Contact = () => {',
+      colors.$color1,
+      colors.$color1,
+      4
+    );
   }
 }

--- a/src/styles/pages/ExpertiseSummaryPage.scss
+++ b/src/styles/pages/ExpertiseSummaryPage.scss
@@ -96,8 +96,23 @@ $font-family-regular: fonts.$font-family-regular;
     }
   }
 
+  @media screen and (min-width: 768px) {
+    @include mixins.component-code-snippet(
+      'const Expertise = () => {',
+      $dark,
+      $color1,
+      4,
+      // * top
+      1,
+      // * bottom
+      0 // * bottom-desktop
+    );
+
+    padding-top: 3rem;
+  }
+
   @media (min-width: 1366px) {
-    flex-direction: row;
+    // flex-direction: row;
     padding-left: 6rem;
 
     &__card {

--- a/src/styles/pages/ProjectsPage.scss
+++ b/src/styles/pages/ProjectsPage.scss
@@ -22,6 +22,17 @@ $font-family-regular: fonts.$font-family-regular;
     colors.$color1
   );
 
+  @media screen and (min-width: 768px) {
+    padding-top: 3rem;
+
+    @include mixins.component-code-snippet(
+      'const Projects = () => {',
+      colors.$color1,
+      colors.$color1,
+      4
+    );
+  }
+
   min-height: 100vh;
 
   // ! START of Splide Styles overrides.


### PR DESCRIPTION
## Pull Request Summary for Issue #2 Completion

---

## Overview:

> The current `Navbar.jsx` component was doing fine, however, I realized that for the desktop view, due to the potential large screen sizes, the user could not understand the navigation concept and feel lost. So I decided to come up with a navigation concept that resembles an IDE file tab navigation (like the one at VScode), this component `FileTabsNavbar.jsx` is more intuitive and user-friendly for large screens.

## Changes Made:

### Added:

#### `.vscode/terminals.json`

- Added a new file to the `.vscode` directory to store the terminal settings for the project.

#### `/src/components/UI/FileTabsNavbar.tsx`

- Added a new component to the `UI` directory to handle the new navigation concept for large screens.

#### `/src/styles/UI/FileTabsNavbar.scss`

- All the styles for the new `FileTabsNavbar` component.

---

### Modified:

#### Note: the following files were modified to accommodate the new `FileTabsNavbar` component.

#### `/src/components/UI/Navbar.tsx`

- I make use of the useState and useEffect hooks to handle the window width and set the state of the `windowWidth` variable.
- I conditionally render the pages paths based on the window width. That is, when the window width is less than 768px (`minWidth` variable), the pages paths will be render along with the social links as this will be the mobile view. Otherwise, only the social links will be rendered.
- I have also added a new Link for my Wellfound (old Angellist) page.

#### `/src/components/pages/HomePage.tsx`

- The same logic applies to the `HomePage` component. But in this case I conditionally render the `FileTabsNAvbar` component based on the window width, that is, when the window width is greater than 768px (`minWidth` variable), the `FileTabsNavbar` component will be rendered.

#### `/src/styles/UI/LineCount.scss`

- Updated the breakpoint from min width of 630px to 768px.
- `.line-count` class will have a margin top of 2.6rem to give space for the new `FileTabsNavbar` component.

#### `/src/styles/UI/Navbar.scss`

- I have only changed the `$elementsInNavbar` variable from 7 to 8 since now I have the Wellfound (old AngelList) link.

#### `/src/styles/pages/AboutPage.scss`

- The mixin `component-code-snippet` will now be at the min-width 768px breakpoint with a top value of 4rem. Again this is to give space for the new `FileTabsNavbar` component.

#### `/src/styles/pages/ContactPage.scss`

#### `/src/styles/pages/ExpertiseSummaryPage.scss`

#### `/src/styles/pages/ProjectsPage.scss`

- The same above logic applies to the `ContactPage`, `ExpertiseSummaryPage` and `ProjectsPage` components.

---

## Reasoning:

> The current navigation concept was not user-friendly for large screens, so I decided to come up with a new concept that is more intuitive and user-friendly.

## Impact:

- n/a.

## Testing:

- n/a.

## Related Issues:

- Closes #2.

## Dependencies:

> None.

## Additional Notes:

> The `Navbar.jsx` component will still be present for the page and social links on mobile view and the new `FileTabsNavbar.jsx` will be hidden. However, on desktop view only the social links will be present and of course, the new `FileTabsNavbar.jsx` will be visible.

---
