### PR TITLE
Issue #9 🎫: LikeButton (UI component) loading state

### DIFF
--- a/src/components/UI/LikeButton.tsx
+++ b/src/components/UI/LikeButton.tsx
@@ -9,6 +9,7 @@ import { SlLike } from 'react-icons/sl';
 import { VscLoading } from 'react-icons/vsc';
 
 import '../../styles/UI/LikeButton.scss';
+import '../../styles/animations/loading-icon.scss';
 
 import involvement from '../../services/involvementAPI/involvementAPI.ts';
 
@@ -68,6 +69,8 @@ const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
 
     if (likedProject) {
       setLikeCount(likedProject.likes);
+      // ? at this point the loading spinner is still showing because of the initial API request.
+      // * so terminate the loading state, to show the like button with the like count.
       setLoadingToFalse();
     }
   }, [itemId, setLoadingToFalse]);

--- a/src/components/UI/LikeButton.tsx
+++ b/src/components/UI/LikeButton.tsx
@@ -6,12 +6,12 @@ import React, {
 } from 'react';
 
 import { SlLike } from 'react-icons/sl';
+import { VscLoading } from 'react-icons/vsc';
 
 import '../../styles/UI/LikeButton.scss';
 
 import involvement from '../../services/involvementAPI/involvementAPI.ts';
 
-/* eslint-disable no-undef */
 interface LikeButtonProps {
   itemId: string;
 }
@@ -20,6 +20,8 @@ const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
   const [wasLiked, setWasLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
   const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const maximumLoadingTime = 5000;
 
   const likeBtn = useRef<HTMLButtonElement>(null);
 
@@ -35,6 +37,15 @@ const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
     }
   }, [wasLiked, styleButton]);
 
+  // ! terminate the loading state after a certain time.
+  // ? this is to prevent the loading state from being stuck.
+  // * and show the user the like button again.
+  const setLoadingToFalse = useCallback(() => {
+    setTimeout(() => {
+      setLoading(false);
+    }, maximumLoadingTime);
+  }, []);
+
   interface Like {
     // * disable camelcase since 'item_id' is the name of the property in the API response.
     // eslint-disable-next-line camelcase
@@ -45,12 +56,21 @@ const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
   const updateLikeCount = useCallback(async () => {
     const likes: Like[] = (await involvement.getLikes()) as Like[];
 
+    if (likes.length === 0) {
+      setError(true);
+      // ? at this point the loading spinner is still showing.
+      // * so terminate the loading state, to show the error message.
+      setLoadingToFalse();
+      return;
+    }
+
     const likedProject = likes.find((like) => like.item_id === itemId);
 
     if (likedProject) {
       setLikeCount(likedProject.likes);
+      setLoadingToFalse();
     }
-  }, [itemId]);
+  }, [itemId, setLoadingToFalse]);
 
   useEffect(() => {
     updateLikeCount();
@@ -64,15 +84,40 @@ const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
       setLikeCount((count) => count + 1);
     }
 
+    if (error) {
+      // ? at this point, there was an error already, so user will attempt to like again.
+      // * so trigger the loading state again.
+      setLoading(true);
+      // * after some time, terminate the loading state, to show like button again.
+      setLoadingToFalse();
+      return;
+    }
+
     const likePosted = await involvement.postLike(itemId);
 
     if (likePosted === 'error') {
       setError(true);
+      return;
     }
 
+    setLoading(false);
     // * after posting a like, update the like count.
     updateLikeCount();
   };
+
+  if (loading) {
+    return (
+      <button
+        type="button"
+        className="like-button text-hue-rotate"
+        ref={likeBtn}
+        onClick={handleLikeSubmit}
+        aria-label="loading"
+      >
+        <VscLoading size={20} className="like-icon loading-icon" />
+      </button>
+    );
+  }
 
   return (
     <button
@@ -80,10 +125,13 @@ const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
       className="like-button text-hue-rotate"
       ref={likeBtn}
       onClick={handleLikeSubmit}
+      aria-label={error ? 'error' : 'like this project'}
     >
       <SlLike size={20} className="like-icon" />
 
-      {likeCount > 0 && (
+      {/* ? when the API likes ary comes empty, likeCount will be 0 */}
+      {/* * so show the error message that was set at the likes.length conditional */}
+      {(likeCount > 0 || error) && (
         <span className="like-button__text">
           &nbsp;
           {!error ? likeCount : 'Error'}

--- a/src/styles/animations/loading-icon.scss
+++ b/src/styles/animations/loading-icon.scss
@@ -1,0 +1,16 @@
+.loading-icon {
+  animation: spin 1s linear infinite;
+  -webkit-animation: spin 1s linear infinite; // * Safari and Chrome.
+  -moz-animation: spin 1s linear infinite; // * Firefox.
+  -o-animation: spin 1s linear infinite; // * Opera.
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
+  }
+}


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/ITurres/iturres-reactive-portfolio/blob/development/public/reactive-portfolio-favicon.png?raw=true" alt="arthur iturres logo" width="80px"/>

  <h2>Pull Request Summary for Issue #9 Completion</h2>
</div>

---

## Overview:

- Issue #9.

> Currently, there is no indicator that every project likes count is fetched from the server. This can be confusing to the user, as they may not know if the likes are being fetched or not. To fix this, a loading spinner will be added to the project's like button, replacing the Like icon until the request is successful or the error message is displayed. This will provide the user with a visual indicator that the likes are being fetched.

## Changes Made:

### Added:

- #### `/src/styles/animations/loading-icon.scss`

- Added a new file to hold the keyframes for the loading icon (spinner) animation.

---

### Modified:

- #### `/src/components/UI/LikeButton.tsx`

- Imported the `VscLoading` icon from `react-icons/vsc` to use as the loading spinner.
- Imported the `loading-icon.scss` stylesheets to use the keyframes for the loading spinner.
- The spinner operates as follows:
  > The loading spinner will be shown in two situations, at first render, i.e
  > when the likes are been fetched, and when the user likes a project, i.e if
  > The user likes it, it will render the spinner until the request is finished and shows the updated number of likes or an error message if the POST request fails.

---

### Deleted:

- n/a.

---

## Impact:

> This change will have a positive impact on the user experience, as it will provide a visual indicator that the likes are being fetched. This will help to reduce confusion and provide a better user experience.

## Testing:

- n/a.

## Related Issues:

- Closes #9.

## Dependencies:

- n/a.

## Additional Notes:

- _**These changes will not be deployed until after issue #14 has been addressed. The next deployment is scheduled to occur following the resolution of issue #14.**_

---
