### PR TITLE
Issue #14 🎫: Fix Excessive Involvement API Requests Triggered by -LikeButton- UI Component.

### DIFF
--- a/src/components/UI/LikeButton.tsx
+++ b/src/components/UI/LikeButton.tsx
@@ -13,11 +13,19 @@ import '../../styles/animations/loading-icon.scss';
 
 import involvement from '../../services/involvementAPI/involvementAPI.ts';
 
+interface Like {
+  // * disable camelcase since 'item_id' is the name of the property in the API response.
+  // eslint-disable-next-line camelcase
+  item_id: string;
+  likes: number;
+  error?: boolean;
+}
 interface LikeButtonProps {
   itemId: string;
+  projectsLikes: Like[];
 }
 
-const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
+const LikeButton: React.FC<LikeButtonProps> = ({ itemId, projectsLikes }) => {
   const [wasLiked, setWasLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
   const [error, setError] = useState(false);
@@ -41,61 +49,77 @@ const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
   // ! terminate the loading state after a certain time.
   // ? this is to prevent the loading state from being stuck.
   // * and show the user the like button again.
-  const setLoadingToFalse = useCallback(() => {
+  const setLoadingFalseAfterTimeout = useCallback(() => {
     setTimeout(() => {
       setLoading(false);
     }, maximumLoadingTime);
   }, []);
 
-  interface Like {
-    // * disable camelcase since 'item_id' is the name of the property in the API response.
-    // eslint-disable-next-line camelcase
-    item_id: string;
-    likes: number;
-  }
-
-  const updateLikeCount = useCallback(async () => {
-    const likes: Like[] = (await involvement.getLikes()) as Like[];
-
-    if (likes.length === 0) {
-      setError(true);
-      // ? at this point the loading spinner is still showing.
-      // * so terminate the loading state, to show the error message.
-      setLoadingToFalse();
+  const updateLikeCount = useCallback(() => {
+    // ? When the Involvement API App ID is new, it will return an empty ary with an empty object
+    // ? while fetching the projectsLikes at 'projectsPage',
+    // * here we will receive an array with one empty object, thats the 1 length.
+    // * so just terminate the loading state, and show the like button with no likes.
+    if (projectsLikes.length === 1) {
+      setLoadingFalseAfterTimeout();
       return;
     }
 
-    const likedProject = likes.find((like) => like.item_id === itemId);
+    // ? If an error was catch at the 'projectsPage' while fetching the projectsLikes,
+    // ? we will receive an array with one object with the error property set to true.
+    if (projectsLikes[0].error) {
+      setError(true);
+      // ? at this point the loading spinner is still showing.
+      // * so terminate the loading state, to show the error message.
+      setLoadingFalseAfterTimeout();
+      return;
+    }
+
+    const likedProject = projectsLikes.find(
+      (project) => project.item_id === itemId,
+    ) as Like | undefined;
 
     if (likedProject) {
       setLikeCount(likedProject.likes);
       // ? at this point the loading spinner is still showing because of the initial API request.
       // * so terminate the loading state, to show the like button with the like count.
-      setLoadingToFalse();
+      setLoadingFalseAfterTimeout();
+    } else {
+      // * If a project has no likes, then terminate the loading state,
+      // * to show the like button with no likes.
+      setLoadingFalseAfterTimeout();
     }
-  }, [itemId, setLoadingToFalse]);
+  }, [itemId, setLoadingFalseAfterTimeout, projectsLikes]);
 
   useEffect(() => {
     updateLikeCount();
   }, [itemId, updateLikeCount]);
 
   const handleLikeSubmit = async () => {
-    setWasLiked((liked) => !liked);
+    // ? Since 'wasLiked' was false, now it will be set to true. This is to
+    // ? trigger the function 'styleButton' to add the 'liked' class to the button.
+    setWasLiked((wasLiked) => !wasLiked);
 
     // * shows an instant update of the like count.
     if (!wasLiked) {
       setLikeCount((count) => count + 1);
+      // * set 'wasLiked' to false, so that the user can like the project again.
+      setWasLiked((wasLiked) => !wasLiked);
     }
 
-    if (error) {
+    if (projectsLikes[0].error || error) {
       // ? at this point, there was an error already, so user will attempt to like again.
       // * so trigger the loading state again.
       setLoading(true);
       // * after some time, terminate the loading state, to show like button again.
-      setLoadingToFalse();
+      setLoadingFalseAfterTimeout();
+      // * and finally show the error message.
+      setError(true);
       return;
     }
 
+    // ? If after all, the error state is still false, then the user can like the project.
+    // * i.e. POST the like to the API.
     const likePosted = await involvement.postLike(itemId);
 
     if (likePosted === 'error') {
@@ -104,8 +128,6 @@ const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
     }
 
     setLoading(false);
-    // * after posting a like, update the like count.
-    updateLikeCount();
   };
 
   if (loading) {
@@ -137,7 +159,7 @@ const LikeButton: React.FC<LikeButtonProps> = ({ itemId }) => {
       {(likeCount > 0 || error) && (
         <span className="like-button__text">
           &nbsp;
-          {!error ? likeCount : 'Error'}
+          {error ? 'Error' : likeCount }
         </span>
       )}
     </button>

--- a/src/components/UI/SplideCarousel.tsx
+++ b/src/components/UI/SplideCarousel.tsx
@@ -10,9 +10,13 @@ import getRandomId from '../../utils/getRandomId.ts';
 /* eslint-disable no-undef */
 interface SplideCarouselProps {
   projectsGroup: Array<{}>;
+  projectsLikes: Array<{}>;
 }
 
-const SplideCarousel: React.FC<SplideCarouselProps> = ({ projectsGroup }) => (
+const SplideCarousel: React.FC<SplideCarouselProps> = ({
+  projectsGroup,
+  projectsLikes,
+}) => (
   <>
     <Splide
       aria-label="Projects carousel"
@@ -39,7 +43,11 @@ const SplideCarousel: React.FC<SplideCarouselProps> = ({ projectsGroup }) => (
       }}
     >
       {projectsGroup.map((projectData) => (
-        <SplideCarouselSlide key={getRandomId()} projectData={projectData} />
+        <SplideCarouselSlide
+          key={getRandomId()}
+          projectData={projectData}
+          projectsLikes={projectsLikes}
+        />
       ))}
     </Splide>
   </>

--- a/src/components/UI/SplideCarouselSlide.tsx
+++ b/src/components/UI/SplideCarouselSlide.tsx
@@ -24,10 +24,12 @@ interface SplideCarouselSlideProps {
       sourceCodeHref: string;
     };
   };
+  projectsLikes: Array<{}>;
 }
 
 const SplideCarouselSlide: React.FC<SplideCarouselSlideProps> = ({
   projectData,
+  projectsLikes,
 }) => (
   <SplideSlide>
     <div className="splide__slide__container">
@@ -53,7 +55,7 @@ const SplideCarouselSlide: React.FC<SplideCarouselSlideProps> = ({
               <summary>Description</summary>
               <p>{projectData.data.description.join(' ')}</p>
             </details>
-            <LikeButton itemId={projectData.id} />
+            <LikeButton itemId={projectData.id} projectsLikes={projectsLikes} />
           </div>
           <div className="splide__slide__overlay__text__stack text-hue-rotate">
             {projectData.data.stack.map((stackItem) => (

--- a/src/components/pages/ProjectsPage.tsx
+++ b/src/components/pages/ProjectsPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 
 import '../../styles/pages/ProjectsPage.scss';
 
@@ -8,14 +8,43 @@ import SplideCarousel from '../UI/SplideCarousel.tsx';
 import getRandomId from '../../utils/getRandomId.ts';
 import setPageTitle from '../../utils/setPageTitle.ts';
 
+import involvement from '../../services/involvementAPI/involvementAPI.ts';
+
 const ProjectsPage: React.FC = () => {
   setPageTitle('My projects 😊');
+
+  const [projectsLikes, setProjectsLikes] = useState([{}]);
+
+  const getProjectsLikes = useCallback(async () => {
+    try {
+      const requestedProjectsLikes = (await involvement.getLikes()) as Array<{}>;
+
+      setProjectsLikes(requestedProjectsLikes);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      setProjectsLikes([
+        {
+          error: true,
+          message: error,
+        },
+      ]);
+    }
+  }, []);
+
+  useEffect(() => {
+    getProjectsLikes();
+  }, [getProjectsLikes]);
 
   return (
     <div className="blend-in-out">
       <main className="projects-page container">
         {Object.values(projects).map((projectGroup) => (
-          <SplideCarousel key={getRandomId()} projectsGroup={projectGroup} />
+          <SplideCarousel
+            key={getRandomId()}
+            projectsGroup={projectGroup}
+            projectsLikes={projectsLikes}
+          />
         ))}
       </main>
     </div>

--- a/src/services/involvementAPI/involvementAPI.ts
+++ b/src/services/involvementAPI/involvementAPI.ts
@@ -22,25 +22,23 @@ const postLike = async (itemId: string) => {
 };
 
 const getLikes = async () => {
-  try {
-    const response = await fetch(`${baseURL}${appId}/likes/`, {
-      method: 'GET',
-    });
+  const response = await fetch(`${baseURL}${appId}/likes/`, {
+    method: 'GET',
+  });
 
-    if (!response.ok) return [];
-
-    // * Only parse the response if it's JSON.
-    // * specially when the involvementAPI : 'appId' is new, the response to be parsed wont be JSON.
-    const contentType = response.headers.get('Content-Type');
-    if (contentType && contentType.includes('application/json')) {
-      const likes = await response.json();
-      if (likes instanceof Array) return likes;
-    }
-
-    return [];
-  } catch (error) {
-    return error;
+  if (!response.ok) {
+    throw new Error(`Error fetching likes: ${response.statusText}`);
   }
+
+  // * Only parse the response if it's JSON.
+  // * specially when the involvementAPI : 'appId' is new, the response to be parsed wont be JSON.
+  const contentType = response.headers.get('Content-Type');
+  if (contentType && contentType.includes('application/json')) {
+    const likes = await response.json();
+    if (likes instanceof Array) return likes;
+  }
+
+  return [];
 };
 
 const involvement = {


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/ITurres/iturres-reactive-portfolio/blob/development/public/reactive-portfolio-favicon.png?raw=true" alt="arthur iturres logo" width="80px"/>

  <h2>Pull Request Summary for Issue #14 Completion</h2>
</div>

---

## Overview:

- Issue #14.

> Issue: 1. When the user goes to the ProjectsPage, each project is rendered with its respective `LikeButton` component, each of these like buttons triggers a request to the involvement API to get all the likes, i.e. 18 requests for the same likes array. That is 17 redundant network requests.
> Issue: 2. When the user likes a project, this **will too trigger a new request** to fetch all the likes, again, a redundant network request.

## Changes Made:

### Added:

- n/a.

---

### Modified:

- #### `/src/services/involvementAPI/involvementAPI.ts`

  - Removed unnecessary try-catch block in the `getLikes` function.
  - Now if the response is not **ok**, the function will throw an error class with the response statusText as the message.

- #### `/src/components/pages/ProjectsPage.tsx`

  - Imported `involvement` from `services/involvementAPI/involvementAPI.ts`.
  - Set a new local state for the projects likes that will be fetched from the API.
  - Created the asynchronous function `getProjectsLikes` that will fetch all the projects likes, this will be done within a try-catch block, if everything goes well, the likes will be set in the local state, if not, the error will be logged and the local state will be also set but to an object with two properties, `error` and `message`. This error object will be used in the UI component `LikeButton` for error handling.
  - In addition, the new local state `projectsLikes` will be passed down to:

    - `SplideCarousel` => `SplideCarouselSlide` to finally reach the `LikeButton` component.

- #### `/src/components/UI/SplideCarousel.tsx`

  - Added a new property to the `SplideCarouselProps` interface, `projectsLikes`, that will be passed down to the `SplideCarouselSlide` component.

- #### `/src/components/UI/SplideCarouselSlide.tsx`

  - Added a new property to the `SplideCarouselSlideProps` interface, `projectsLikes`, that will be passed down to the `LikeButton` component.

- #### `/src/components/UI/LikeButton.tsx`

#### Multiple important changes have been made here:

  - The `Like` interface will be moved outside the component and it will now take a new property, `error` with the type of boolean.
  - Update the `LikeButtonProps` interface to take the new `projectsLikes` prop that has been passed down from the `ProjectsPage` component through the `SplideCarousel` and `SplideCarouselSlide` UI components.
  - Renamed the old `setLoadingToFalse` function for a more descriptive name, `setLoadingFalseAfterTimeout` and all the references to it.
  - Removed the projects likes fetching logic from the `updateLikeCount` function since this is now done in the `ProjectsPage` component.
  - In this `updateLikeCount` function, there are new conditions to handle certain scenarios:

    - Now we will check for the `projectsLikes` prop at index 0 to have the error property set to true, if so, we will set the Error local state to true and invoke `setLoadingFalseAfterTimeout`.
    - The condition to check for the length of the `projectsLikes` array to be 1 is still in used, because if a new involvement App API Id is set, the response will be an array with a single object. If that happens then we will just invoke `setLoadingFalseAfterTimeout` to show the loading spinner and finally the lke button with no likes.
    - Now when we filter the `projectsLikes` array to find the project likes by the `itemId` passed down as a prop, we will cast this as a `Like` array or undefined if none is found.
    - If the `likedProject` is not undefined, the block is the same as before, but now it it is undefined, the only thing we will do is to invoke `setLoadingFalseAfterTimeout` to show the loading spinner and finally the lke button with no likes.

  - In the `handleLikeSubmit` function, there were also a few changes:

    - Renamed the `wasLiked` argument state name at the setState function.
    - Now the conditional for the error state will also include the check for the `projectsLikes` prop at index 0 to have the error property set to true, if so, we will set the loading local state to true, invoke `setLoadingFalseAfterTimeout` and finally set the Error local state to true to show the user the error button instead of the like button. All these checks are done to prevent the user to POST a new like if the API is not working properly.
    - And finally, the invocation of the old async function `updateLikeCount` has been removed, since this is not longer needed.

  - At line 162: Invert the conditional statement to prioritize displaying an error message when an error is present, otherwise display the like count. This change is also to always check for truthy values.

---

### Deleted:

- n/a.

---

## Impact:

- **These changes have a massive impact. The `ProjectsPage` component now fetches all project likes in a single request, improving efficiency by eliminating redundant network requests. This data is then passed down to the `LikeButton` component via `SplideCarousel` and `SplideCarouselSlide`, ensuring each project renders without additional requests. As of 08-03-2024, with 19 projects, this approach prevents N redundant requests. Additionally, users no longer trigger new requests when liking a project. When a user likes a project, the like is posted, and the new count is rendered using local state. Subsequent visits to the page or reloading trigger a new fetch-all-likes request to update the likes with real data.**

## Testing:

- n/a.

## Related Issues:

- Closes #14.

## Dependencies:

- n/a.

## Additional Notes:

- n/a.

---
